### PR TITLE
Add metadata

### DIFF
--- a/.manifest/things-dev.yaml
+++ b/.manifest/things-dev.yaml
@@ -17,7 +17,7 @@ features:
     - command: /things-add
       url: https://zaratan.ngrok.io/slack/events
       description: Add a thing
-      usage_hint: "[type]-[name]-[quantity]-[price]"
+      usage_hint: "[type]-[name]-[unit]-[price]"
     - command: /things-del
       url: https://zaratan.ngrok.io/slack/events
       description: Delete a thing

--- a/.manifest/things.yaml
+++ b/.manifest/things.yaml
@@ -17,7 +17,7 @@ features:
     - command: /things-add
       url: https://things.mirror.zaratan.world/slack/events
       description: Add a thing
-      usage_hint: "[type]-[name]-[quantity]-[price]"
+      usage_hint: "[type]-[name]-[unit]-[price]"
     - command: /things-del
       url: https://things.mirror.zaratan.world/slack/events
       description: Delete a thing

--- a/migrations/20220329100600_Thing.js
+++ b/migrations/20220329100600_Thing.js
@@ -5,7 +5,7 @@ exports.up = function(knex, Promise) {
         t.string('houseId').references('House.slackId').notNull();
         t.string('type').notNull();
         t.string('name').notNull();
-        t.string('quantity');
+        t.string('quantity'); // TODO: Deprecated, remove
         t.float('value').notNull().defaultTo(0);
         t.boolean('active').notNull().defaultTo(true);
         t.unique(['houseId', 'type', 'name']);

--- a/migrations/20220329100610_ThingBuy.js
+++ b/migrations/20220329100610_ThingBuy.js
@@ -12,6 +12,7 @@ exports.up = function(knex, Promise) {
         t.boolean('valid').notNull().defaultTo(true);
         t.string('fulfilledBy').references('Resident.slackId');
         t.timestamp('fulfilledAt');
+        t.json('metadata');
     });
 };
 

--- a/migrations/20230808231940_add_metadata_chore.js
+++ b/migrations/20230808231940_add_metadata_chore.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('Chore', function(t) {
+    t.json('metadata');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('Chore', function(t) {
+    t.dropColumn('metadata');
+  });
+};

--- a/migrations/20230808231940_add_metadata_chore_break.js
+++ b/migrations/20230808231940_add_metadata_chore_break.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('ChoreBreak', function(t) {
+    t.json('metadata');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('ChoreBreak', function(t) {
+    t.dropColumn('metadata');
+  });
+};

--- a/migrations/20230808231940_add_metadata_chore_value.js
+++ b/migrations/20230808231940_add_metadata_chore_value.js
@@ -3,7 +3,7 @@
  * @returns { Promise<void> }
  */
 exports.up = function(knex) {
-  return knex.schema.alterTable('ThingBuy', function(t) {
+  return knex.schema.alterTable('ChoreValue', function(t) {
     t.json('metadata');
   });
 };
@@ -13,7 +13,7 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  return knex.schema.alterTable('ThingBuy', function(t) {
+  return knex.schema.alterTable('ChoreValue', function(t) {
     t.dropColumn('metadata');
   });
 };

--- a/migrations/20230808231940_add_metadata_chore_value.js
+++ b/migrations/20230808231940_add_metadata_chore_value.js
@@ -5,6 +5,8 @@
 exports.up = function(knex) {
   return knex.schema.alterTable('ChoreValue', function(t) {
     t.json('metadata');
+    t.dropColumn('ranking');
+    t.dropColumn('residents');
   });
 };
 
@@ -15,5 +17,7 @@ exports.up = function(knex) {
 exports.down = function(knex) {
   return knex.schema.alterTable('ChoreValue', function(t) {
     t.dropColumn('metadata');
+    t.float('ranking');
+    t.integer('residents');
   });
 };

--- a/migrations/20230808231940_add_metadata_heart.js
+++ b/migrations/20230808231940_add_metadata_heart.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('Heart', function(t) {
+    t.tinyint('type').notNull().defaultTo(0);
+    t.json('metadata');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('Heart', function(t) {
+    t.dropColumn('type');
+    t.dropColumn('metadata');
+  });
+};

--- a/migrations/20230808231940_add_metadata_heart_challenge.js
+++ b/migrations/20230808231940_add_metadata_heart_challenge.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('HeartChallenge', function(t) {
+    t.json('metadata');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('HeartChallenge', function(t) {
+    t.dropColumn('metadata');
+  });
+};

--- a/migrations/20230808231940_add_metadata_poll.js
+++ b/migrations/20230808231940_add_metadata_poll.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('Poll', function(t) {
+    t.json('metadata');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('Poll', function(t) {
+    t.dropColumn('metadata');
+  });
+};

--- a/migrations/20230808231940_add_metadata_thing.js
+++ b/migrations/20230808231940_add_metadata_thing.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('Thing', function(t) {
+    t.json('metadata');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('Thing', function(t) {
+    t.dropColumn('metadata');
+  });
+};

--- a/scripts/migrate-things.js
+++ b/scripts/migrate-things.js
@@ -1,0 +1,23 @@
+const { db } = require('../src/core/db');
+const { Things } = require('../src/core/index');
+
+async function main () {
+  try {
+    const things = await db('Thing').returning('*');
+
+    things.forEach((thing) => {
+      const splitQuantity = thing.quantity.split(' x ');
+      const unit = splitQuantity[splitQuantity.length - 1].trim();
+      thing.metadata = { unit };
+    });
+
+    await Things.updateThing(things);
+
+    console.log(`Migrated ${things.length} things`);
+    process.exit(0);
+  } catch (err) {
+    console.error('An error occurred:', err);
+  }
+}
+
+main();

--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -309,7 +309,7 @@ app.view('chores-break-callback', async ({ ack, body }) => {
     await common.postEphemeral(app, choresOauth, choresChannel, residentId, text);
   } else {
     // Record the break
-    await Chores.addChoreBreak(houseId, residentId, breakStart, breakEnd);
+    await Chores.addChoreBreak(houseId, residentId, breakStart, breakEnd, circumstance);
     const text = `<@${residentId}> is taking a *${breakDays}-day* break ` +
         `starting ${breakStart.toDateString()} :beach_with_umbrella:\n` +
         `_${circumstance}_`;

--- a/src/bolt/hearts.app.js
+++ b/src/bolt/hearts.app.js
@@ -141,7 +141,7 @@ app.view('hearts-challenge-callback', async ({ ack, body }) => {
   // Initiate the challenge
   const now = new Date();
   const quorum = await Hearts.getChallengeQuorum(houseId, challengeeId, numHearts, now);
-  const [ challenge ] = await Hearts.issueChallenge(houseId, residentId, challengeeId, numHearts, now);
+  const [ challenge ] = await Hearts.issueChallenge(houseId, residentId, challengeeId, numHearts, now, circumstance);
   await Polls.submitVote(challenge.pollId, residentId, now, YAY);
 
   const text = 'Someone just issued a hearts challenge';

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -200,14 +200,16 @@ app.view('things-buy-callback', async ({ ack, body }) => {
   const houseId = body.team.id;
 
   // // https://api.slack.com/reference/interaction-payloads/views#view_submission_fields
-  const blockIndex = body.view.blocks.length - 1;
-  const blockId = body.view.blocks[blockIndex].block_id;
-  const thingId = parseInt(body.view.state.values[blockId].options.selected_option.value);
+  const numBlocks = body.view.blocks.length;
+  const thingBlockId = body.view.blocks[numBlocks - 2].block_id;
+  const quantityBlockId = body.view.blocks[numBlocks - 1].block_id;
+  const thingId = parseInt(body.view.state.values[thingBlockId].options.selected_option.value);
+  const quantity = parseInt(body.view.state.values[quantityBlockId].quantity.value);
 
   // Perform the buy
   const now = new Date();
   const thing = await Things.getThing(thingId);
-  const [ buy ] = await Things.buyThing(houseId, thing.id, residentId, now, thing.value, 1);
+  const [ buy ] = await Things.buyThing(houseId, thing.id, residentId, now, thing.value, quantity);
   await Polls.submitVote(buy.pollId, residentId, now, YAY);
 
   const residents = await Admin.getResidents(houseId);

--- a/src/bolt/things.app.js
+++ b/src/bolt/things.app.js
@@ -80,8 +80,8 @@ app.command('/things-add', async ({ ack, command }) => {
     'If the thing already exists, the command does nothing.';
   } else if (await common.isAdmin(app, thingsOauth, command)) {
     const [ houseId, active ] = [ command.team_id, true ];
-    const { type, name, quantity, value } = views.parseThingAdd(command.text);
-    const [ thing ] = await Things.updateThing({ houseId, type, name, quantity, value, active });
+    const { type, name, unit, value } = views.parseThingAdd(command.text);
+    const [ thing ] = await Things.updateThing({ houseId, type, name, value, active, metadata: { unit } });
     text = `${views.formatThing(thing)} added to the things list :star-struck:`;
   } else {
     text = ':warning: Only admins can update the things list...';
@@ -146,8 +146,8 @@ app.command('/things-resolved', async ({ ack, command }) => {
     const houseId = command.team_id;
     const now = new Date();
 
-    const buys = await Things.getUnfulfilledThingBuys(houseId, now);
-    const parsedResolvedBuys = views.parseResolvedThingBuys(buys);
+    const unfulfilledBuys = await Things.getUnfulfilledThingBuys(houseId, now);
+    const parsedResolvedBuys = views.parseResolvedThingBuys(unfulfilledBuys);
     text = `Resolved buys not yet fulfilled:${parsedResolvedBuys}`;
   }
 

--- a/src/bolt/things.views.js
+++ b/src/bolt/things.views.js
@@ -107,6 +107,18 @@ exports.thingsBuyView = function (things) {
           placeholder: { type: 'plain_text', text: 'Choose a thing', emoji: true },
           options: mappedThings
         }
+      },
+      {
+        type: 'input',
+        label: { type: 'plain_text', text: 'Amount to buy', emoji: true },
+        element: {
+          type: 'number_input',
+          action_id: 'quantity',
+          placeholder: { type: 'plain_text', text: 'Choose number of units', emoji: true },
+          initial_value: '1',
+          min_value: '0',
+          is_decimal_allowed: false
+        }
       }
     ]
   };

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,9 @@ exports.YAY = 1;
 exports.CANCEL = undefined;
 
 exports.SLACKBOT = 'USLACKBOT';
+
+exports.HEART_TYPE_UNKNOWN = 0;
+exports.HEART_TYPE_REGEN = 1;
+exports.HEART_TYPE_CHALLENGE = 2;
+exports.HEART_TYPE_KARMA = 3;
+exports.HEART_TYPE_CHORE = 4;

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -156,8 +156,7 @@ exports.updateChoreValues = async function (houseId, updateTime) {
       choreId: chore.id,
       valuedAt: updateTime,
       value: chore.ranking * updateScalar,
-      ranking: chore.ranking,
-      residents: residentCount
+      metadata: { ranking: chore.ranking, residents: residentCount }
     };
   });
 

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -1,6 +1,6 @@
 const { db } = require('./db');
 
-const { HOUR, DAY } = require('../constants');
+const { HOUR, DAY, HEART_TYPE_CHORE } = require('../constants');
 const { getMonthStart, getMonthEnd, getPrevMonthEnd, getNextMonthStart, getDateStart } = require('../utils');
 
 const {
@@ -333,7 +333,7 @@ exports.addChorePenalty = async function (houseId, residentId, currentTime) {
     if (hearts.sum === null) { return []; } // Don't penalize if not initialized
 
     const penaltyAmount = await exports.calculatePenalty(residentId, penaltyTime);
-    return Hearts.generateHearts(houseId, residentId, penaltyTime, -penaltyAmount);
+    return Hearts.generateHearts(houseId, residentId, HEART_TYPE_CHORE, penaltyTime, -penaltyAmount);
   } else {
     return [];
   }

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -257,9 +257,9 @@ exports.getAllChorePoints = async function (claimedBy, startTime, endTime) {
 
 // Chore Breaks
 
-exports.addChoreBreak = async function (houseId, residentId, startDate, endDate) {
+exports.addChoreBreak = async function (houseId, residentId, startDate, endDate, circumstance) {
   return db('ChoreBreak')
-    .insert({ houseId, residentId, startDate, endDate })
+    .insert({ houseId, residentId, startDate, endDate, metadata: { circumstance } })
     .returning('*');
 };
 

--- a/src/core/hearts.js
+++ b/src/core/hearts.js
@@ -207,7 +207,7 @@ exports.generateKarmaHearts = async function (houseId, currentTime, numWinners) 
       const residentId = winner.slackId;
       const residentHearts = await exports.getHearts(residentId, generatedAt);
       const value = Math.min(1, Math.max(0, karmaMaxHearts - residentHearts.sum)); // Bring to maximum
-      karmaHearts.push({ houseId, residentId, generatedAt, value });
+      karmaHearts.push({ houseId, residentId, generatedAt, value, metadata: { ranking: winner.ranking } });
     }
 
     return db('Heart').insert(karmaHearts).returning('*');

--- a/src/core/hearts.js
+++ b/src/core/hearts.js
@@ -80,11 +80,11 @@ exports.regenerateHearts = async function (houseId, residentId, currentTime) {
 
 // Challenges
 
-exports.issueChallenge = async function (houseId, challengerId, challengeeId, value, challengedAt) {
+exports.issueChallenge = async function (houseId, challengerId, challengeeId, value, challengedAt, circumstance) {
   const [ poll ] = await Polls.createPoll(challengedAt, heartsPollLength);
 
   return db('HeartChallenge')
-    .insert({ houseId, challengerId, challengeeId, challengedAt, value, pollId: poll.id })
+    .insert({ houseId, challengerId, challengeeId, challengedAt, value, pollId: poll.id, metadata: { circumstance } })
     .returning('*');
 };
 

--- a/src/core/things.js
+++ b/src/core/things.js
@@ -148,7 +148,7 @@ exports.getUnfulfilledThingBuys = async function (houseId, currentTime) {
       'ThingBuy.id',
       'Thing.type',
       'Thing.name',
-      'Thing.quantity',
+      'Thing.metadata AS thingMetadata',
       'ThingBuy.value',
       'ThingBuy.resolvedAt',
       'ThingBuy.metadata'

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -541,9 +541,9 @@ describe('Chores', async () => {
       await Chores.claimChore(HOUSE, restock.id, RESIDENT3, feb1);
 
       // Everyone takes half the month off
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, feb15);
-      await Chores.addChoreBreak(HOUSE, RESIDENT2, feb1, feb15);
-      await Chores.addChoreBreak(HOUSE, RESIDENT3, feb1, feb15);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, feb15, '');
+      await Chores.addChoreBreak(HOUSE, RESIDENT2, feb1, feb15, '');
+      await Chores.addChoreBreak(HOUSE, RESIDENT3, feb1, feb15, '');
 
       let penalty;
       const penaltyTime = new Date(getNextMonthStart(feb1).getTime() + penaltyDelay);
@@ -604,16 +604,20 @@ describe('Chores', async () => {
       choreBreaks = await Chores.getChoreBreaks(HOUSE, now);
       expect(choreBreaks.length).to.equal(0);
 
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, now, oneDay);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, now, oneDay, 'Visiting family');
+
       choreBreaks = await Chores.getChoreBreaks(HOUSE, now);
       expect(choreBreaks.length).to.equal(1);
+      expect(choreBreaks[0].metadata.circumstance).to.equal('Visiting family');
 
       await Chores.deleteChoreBreak(choreBreaks[0].id);
+
       choreBreaks = await Chores.getChoreBreaks(HOUSE, now);
       expect(choreBreaks.length).to.equal(0);
 
-      await Chores.addChoreBreak(HOUSE, RESIDENT2, now, oneDay);
-      await Chores.addChoreBreak(HOUSE, RESIDENT2, now, twoDays);
+      await Chores.addChoreBreak(HOUSE, RESIDENT2, now, oneDay, '');
+      await Chores.addChoreBreak(HOUSE, RESIDENT2, now, twoDays, '');
+
       choreBreaks = await Chores.getChoreBreaks(HOUSE, now);
       expect(choreBreaks.length).to.equal(2);
       choreBreaks = await Chores.getChoreBreaks(HOUSE, oneDay);
@@ -644,22 +648,22 @@ describe('Chores', async () => {
       expect(residentCount).to.equal(3);
 
       // Will count active breaks
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, now, twoDays);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, now, twoDays, '');
       residentCount = await Chores.getActiveResidentCount(HOUSE, now);
       expect(residentCount).to.equal(2);
 
       // Can handle overlapping breaks
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, now, oneDay);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, now, oneDay, '');
       residentCount = await Chores.getActiveResidentCount(HOUSE, now);
       expect(residentCount).to.equal(2);
 
       // Can handle new breaks by the same user
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, oneWeek, twoWeeks);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, oneWeek, twoWeeks, '');
       residentCount = await Chores.getActiveResidentCount(HOUSE, oneWeek);
       expect(residentCount).to.equal(2);
 
       // Will also exclude if break extends across months
-      await Chores.addChoreBreak(HOUSE, RESIDENT2, lastMonth, nextMonth);
+      await Chores.addChoreBreak(HOUSE, RESIDENT2, lastMonth, nextMonth, '');
       residentCount = await Chores.getActiveResidentCount(HOUSE, now);
       expect(residentCount).to.equal(1);
 
@@ -668,7 +672,7 @@ describe('Chores', async () => {
       expect(residentCount).to.equal(3);
 
       // Will not count breaks in the future
-      await Chores.addChoreBreak(HOUSE, RESIDENT3, oneDay, oneWeek);
+      await Chores.addChoreBreak(HOUSE, RESIDENT3, oneDay, oneWeek, '');
       residentCount = await Chores.getActiveResidentCount(HOUSE, now);
       expect(residentCount).to.equal(1);
     });
@@ -688,27 +692,27 @@ describe('Chores', async () => {
       expect(activeDays).to.equal(1);
 
       // Take the first week off
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, feb8);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, feb8, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.75);
 
       // Take the third week off
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb15, feb22);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb15, feb22, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.5);
 
       // Take time off next month, has no effect
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, mar1, mar15);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, mar1, mar15, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.5);
 
       // Take the first two weeks off, this break overlaps with the first break
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, feb15);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb1, feb15, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.25);
 
       // Take the last week off, this break stretches into the next month
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb22, mar8);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb22, mar8, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.0);
     });
@@ -723,12 +727,12 @@ describe('Chores', async () => {
       let activeDays;
 
       // Overlap last and first weeks
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, jan25, feb8);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, jan25, feb8, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.75);
 
       // Overlap last and first weeks
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb22, mar8);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb22, mar8, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0.5);
     });
@@ -739,7 +743,7 @@ describe('Chores', async () => {
       const jan25 = new Date(feb1.getTime() - 7 * DAY);
 
       // Add a six-week break
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, jan25, mar8);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, jan25, mar8, '');
       const activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb1);
       expect(activeDays).to.equal(0);
     });
@@ -760,7 +764,7 @@ describe('Chores', async () => {
       expect(activeDays).to.equal(1);
 
       // Add a six-week break from feb into april (6 day break)
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb15, apr7);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, feb15, apr7, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, feb15);
       expect(activeDays).to.equal(0.5);
 
@@ -771,12 +775,12 @@ describe('Chores', async () => {
       expect(activeDays).to.equal(0.8);
 
       // Add a week-long break mid-april (12 day break)
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, apr10, apr22);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, apr10, apr22, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, apr1);
       expect(activeDays).to.equal(0.4);
 
       // Add a two-week break spanning april and may (6 day break)
-      await Chores.addChoreBreak(HOUSE, RESIDENT1, apr25, may5);
+      await Chores.addChoreBreak(HOUSE, RESIDENT1, apr25, may5, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT1, apr1);
       expect(activeDays).to.equal(0.2);
     });
@@ -796,7 +800,7 @@ describe('Chores', async () => {
       expect(activeDays).to.equal(0.75);
 
       // Can combine with regular breaks
-      await Chores.addChoreBreak(HOUSE, RESIDENT3, feb22, mar1);
+      await Chores.addChoreBreak(HOUSE, RESIDENT3, feb22, mar1, '');
       activeDays = await Chores.getActiveResidentPercentage(RESIDENT3, feb1);
       expect(activeDays).to.equal(0.5);
     });

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -69,9 +69,9 @@ describe('Chores', async () => {
 
     it('can set and query for chore values in a time range', async () => {
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: dishes.id, valuedAt: now, value: 5, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: now, value: 20, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 10 },
+        { choreId: dishes.id, valuedAt: now, value: 5 },
+        { choreId: sweeping.id, valuedAt: now, value: 20 }
       ]);
 
       const endTime = new Date(now.getTime() + MINUTE);
@@ -86,9 +86,9 @@ describe('Chores', async () => {
 
     it('can set and query for all current chore values', async () => {
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: dishes.id, valuedAt: now, value: 5, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: now, value: 20, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 10 },
+        { choreId: dishes.id, valuedAt: now, value: 5 },
+        { choreId: sweeping.id, valuedAt: now, value: 20 }
       ]);
 
       const soon = new Date(now.getTime() + HOUR);
@@ -222,8 +222,8 @@ describe('Chores', async () => {
       const t1 = new Date(2000, 0, 2); // January 2
 
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: t0, value: 10, ranking: 0, residents: 0 },
-        { choreId: dishes.id, valuedAt: t1, value: 10, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: t0, value: 10 },
+        { choreId: dishes.id, valuedAt: t1, value: 10 }
       ]);
 
       const t2 = new Date(t1.getTime() + HOUR); // 1 hour
@@ -235,7 +235,7 @@ describe('Chores', async () => {
       const t0 = new Date(2000, 0, 1);
 
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: t0, value: 10, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: t0, value: 10 }
       ]);
 
       const t1 = new Date(t0.getTime() + (HOUR + 10 * MINUTE));
@@ -253,11 +253,11 @@ describe('Chores', async () => {
       expect(intervalScalar).to.almost.equal(0.002688172043010753);
     });
 
-    it('can update chore values, storing useful contextual data', async () => {
+    it('can update chore values, storing useful metadata', async () => {
       const choreValues = await Chores.updateChoreValues(HOUSE, now);
 
-      expect(choreValues[0].ranking).to.almost.equal(0.3333333333333333);
-      expect(choreValues[0].residents).to.equal(2);
+      expect(choreValues[0].metadata.ranking).to.almost.equal(0.3333333333333333);
+      expect(choreValues[0].metadata.residents).to.equal(2);
     });
 
     it('can do an end-to-end update of chore values', async () => {
@@ -308,8 +308,8 @@ describe('Chores', async () => {
 
     it('can claim a chore', async () => {
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: dishes.id, valuedAt: now, value: 5, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 10 },
+        { choreId: dishes.id, valuedAt: now, value: 5 }
       ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
@@ -325,11 +325,11 @@ describe('Chores', async () => {
 
     it('can claim a chore incrementally', async () => {
       // Two separate events
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 5, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 5 } ]);
       const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: soon, value: 20, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: soon, value: 20 } ]);
       const [ choreClaim2 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT2, soon);
 
       expect(choreClaim1.claimedBy).to.equal(RESIDENT1);
@@ -339,7 +339,7 @@ describe('Chores', async () => {
     });
 
     it('can successfully resolve a claim', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       await Polls.submitVote(choreClaim.pollId, RESIDENT1, soon, YAY);
@@ -353,9 +353,9 @@ describe('Chores', async () => {
 
     it('can successfully resolve many claims at once', async () => {
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: restock.id, valuedAt: soon, value: 10, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 10 },
+        { choreId: sweeping.id, valuedAt: now, value: 10 },
+        { choreId: restock.id, valuedAt: soon, value: 10 }
       ]);
       const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       const [ choreClaim2 ] = await Chores.claimChore(HOUSE, sweeping.id, RESIDENT1, now);
@@ -384,7 +384,7 @@ describe('Chores', async () => {
     });
 
     it('cannot resolve a claim before the poll closes ', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       await expect(Chores.resolveChoreClaim(choreClaim.id, soon))
@@ -392,7 +392,7 @@ describe('Chores', async () => {
     });
 
     it('cannot resolve a claim twice', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       await Chores.resolveChoreClaim(choreClaim.id, challengeEnd);
@@ -402,7 +402,7 @@ describe('Chores', async () => {
     });
 
     it('cannot successfully resolve a claim without two positive votes', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       await Polls.submitVote(choreClaim.pollId, RESIDENT1, soon, YAY);
@@ -412,7 +412,7 @@ describe('Chores', async () => {
     });
 
     it('cannot successfully resolve a claim without a passing vote', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       await Polls.submitVote(choreClaim.pollId, RESIDENT1, soon, YAY);
@@ -431,10 +431,10 @@ describe('Chores', async () => {
       const t3 = new Date(t0.getTime() + choresPollLength);
       const t4 = new Date(t1.getTime() + choresPollLength);
 
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t0, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t0, value: 10 } ]);
       const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, t0);
 
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t1, value: 5, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t1, value: 5 } ]);
       const [ choreClaim2 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT2, t1);
 
       // Both claims pass
@@ -459,10 +459,10 @@ describe('Chores', async () => {
       const t3 = new Date(t0.getTime() + choresPollLength);
       const t4 = new Date(t1.getTime() + choresPollLength);
 
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t0, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t0, value: 10 } ]);
       const [ choreClaim1 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, t0);
 
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t1, value: 5, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: t1, value: 5 } ]);
       const [ choreClaim2 ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT2, t1);
 
       // First claim is rejected
@@ -487,8 +487,8 @@ describe('Chores', async () => {
       const y2k = new Date(2000, 1, 1);
 
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: now, value: 20, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 10 },
+        { choreId: sweeping.id, valuedAt: now, value: 20 }
       ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await Chores.claimChore(HOUSE, sweeping.id, RESIDENT1, now);
@@ -509,9 +509,9 @@ describe('Chores', async () => {
 
     it('can calculate chore penalties', async () => {
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 91, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: now, value: 80, ranking: 0, residents: 0 },
-        { choreId: restock.id, valuedAt: now, value: 69, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 91 },
+        { choreId: sweeping.id, valuedAt: now, value: 80 },
+        { choreId: restock.id, valuedAt: now, value: 69 }
       ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await Chores.claimChore(HOUSE, sweeping.id, RESIDENT2, now);
@@ -532,9 +532,9 @@ describe('Chores', async () => {
       const feb15 = new Date(feb1.getTime() + 14 * DAY);
 
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: feb1, value: 60, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: feb1, value: 50, ranking: 0, residents: 0 },
-        { choreId: restock.id, valuedAt: feb1, value: 40, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: feb1, value: 60 },
+        { choreId: sweeping.id, valuedAt: feb1, value: 50 },
+        { choreId: restock.id, valuedAt: feb1, value: 40 }
       ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, feb1);
       await Chores.claimChore(HOUSE, sweeping.id, RESIDENT2, feb1);
@@ -558,7 +558,7 @@ describe('Chores', async () => {
     it('can add a penalty at the right time', async () => {
       await Hearts.initialiseResident(HOUSE, RESIDENT1, now);
 
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 50, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 50 } ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       let penaltyHeart;
@@ -573,7 +573,7 @@ describe('Chores', async () => {
     });
 
     it('cannot penalize before initialized', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 50, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 50 } ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       let penaltyHeart;
@@ -810,9 +810,9 @@ describe('Chores', async () => {
 
     it('can get the largest valid chore claim', async () => {
       await db('ChoreValue').insert([
-        { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 },
-        { choreId: restock.id, valuedAt: now, value: 30, ranking: 0, residents: 0 },
-        { choreId: sweeping.id, valuedAt: now, value: 20, ranking: 0, residents: 0 }
+        { choreId: dishes.id, valuedAt: now, value: 10 },
+        { choreId: restock.id, valuedAt: now, value: 30 },
+        { choreId: sweeping.id, valuedAt: now, value: 20 }
       ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await Chores.claimChore(HOUSE, restock.id, RESIDENT1, now);
@@ -823,7 +823,7 @@ describe('Chores', async () => {
     });
 
     it('can gift chore points', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
 
       await Chores.giftChorePoints(HOUSE, RESIDENT1, RESIDENT2, now, 6);
@@ -841,7 +841,7 @@ describe('Chores', async () => {
     });
 
     it('can have a negative balance if a claim is denied after gifting', async () => {
-      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10, ranking: 0, residents: 0 } ]);
+      await db('ChoreValue').insert([ { choreId: dishes.id, valuedAt: now, value: 10 } ]);
       const [ choreClaim ] = await Chores.claimChore(HOUSE, dishes.id, RESIDENT1, now);
       await Chores.giftChorePoints(HOUSE, RESIDENT1, RESIDENT2, now, 6);
 

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -180,8 +180,16 @@ describe('Hearts', async () => {
       await Hearts.initialiseResident(HOUSE, RESIDENT2, now);
     });
 
+    it('can issue a challenge', async () => {
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 2, now, 'Rude behavior');
+      expect(challenge.challengerId).to.equal(RESIDENT1);
+      expect(challenge.challengeeId).to.equal(RESIDENT2);
+      expect(challenge.value).to.equal(2);
+      expect(challenge.metadata.circumstance).to.equal('Rude behavior');
+    });
+
     it('can resolve a challenge where the challenger wins', async () => {
-      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
 
       await Polls.submitVote(challenge.pollId, RESIDENT1, now, YAY);
       await Polls.submitVote(challenge.pollId, RESIDENT2, now, NAY);
@@ -198,7 +206,7 @@ describe('Hearts', async () => {
     });
 
     it('can resolve a challenge where the challenger loses', async () => {
-      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
 
       await Polls.submitVote(challenge.pollId, RESIDENT1, now, YAY);
       await Polls.submitVote(challenge.pollId, RESIDENT2, now, NAY);
@@ -213,7 +221,7 @@ describe('Hearts', async () => {
     });
 
     it('can resolve a challenge where the quorum is not reached', async () => {
-      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
 
       // Quorum is 2, only 1 vote is submitted
       await Polls.submitVote(challenge.pollId, RESIDENT1, now, YAY);
@@ -227,9 +235,9 @@ describe('Hearts', async () => {
     });
 
     it('can resolve challenges in bulk', async () => {
-      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
-      await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
-      await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, soon);
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
+      await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
+      await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, soon, '');
 
       await Polls.submitVote(challenge.pollId, RESIDENT1, now, YAY);
       await Polls.submitVote(challenge.pollId, RESIDENT3, now, YAY);
@@ -245,7 +253,7 @@ describe('Hearts', async () => {
     });
 
     it('cannot resolve a challenge before the poll is closed', async () => {
-      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
 
       await Polls.submitVote(challenge.pollId, RESIDENT1, now, YAY);
       await Polls.submitVote(challenge.pollId, RESIDENT2, now, NAY);
@@ -256,7 +264,7 @@ describe('Hearts', async () => {
     });
 
     it('cannot resolve a challenge twice', async () => {
-      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now);
+      const [ challenge ] = await Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT2, 1, now, '');
 
       await Polls.submitVote(challenge.pollId, RESIDENT1, now, YAY);
       await Polls.submitVote(challenge.pollId, RESIDENT2, now, NAY);
@@ -281,10 +289,10 @@ describe('Hearts', async () => {
     });
 
     it('cannot challenge oneself', async () => {
-      const dbError = 'insert into "HeartChallenge" ("challengedAt", "challengeeId", "challengerId", "houseId", "pollId", "value") ' +
-        'values ($1, $2, $3, $4, $5, $6) returning * - new row for relation "HeartChallenge" violates check constraint "HeartChallenge_check';
+      const dbError = 'insert into "HeartChallenge" ("challengedAt", "challengeeId", "challengerId", "houseId", "metadata", "pollId", "value") ' +
+        'values ($1, $2, $3, $4, $5, $6, $7) returning * - new row for relation "HeartChallenge" violates check constraint "HeartChallenge_check';
 
-      await expect(Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT1, 1, now))
+      await expect(Hearts.issueChallenge(HOUSE, RESIDENT1, RESIDENT1, 1, now, ''))
         .to.be.rejectedWith(dbError);
     });
   });

--- a/test/hearts.test.js
+++ b/test/hearts.test.js
@@ -374,6 +374,7 @@ describe('Hearts', async () => {
       [ karmaHeart ] = await Hearts.generateKarmaHearts(HOUSE, nextMonthKarma, 1);
       expect(karmaHeart.residentId).to.equal(RESIDENT3);
       expect(karmaHeart.value).to.equal(1);
+      expect(karmaHeart.metadata.ranking).to.equal(0.6423540742590585);
 
       // But not twice
       [ karmaHeart ] = await Hearts.generateKarmaHearts(HOUSE, nextMonthKarma, 1);

--- a/test/things.test.js
+++ b/test/things.test.js
@@ -70,7 +70,7 @@ describe('Things', async () => {
 
       things = await Things.getThings(HOUSE);
       expect(things.length).to.equal(1);
-      expect(things.find(thing => thing.name === RICE).value).to.equal(20);
+      expect(things[0].value).to.equal(20);
     });
 
     it('can get a thing by id', async () => {
@@ -86,8 +86,8 @@ describe('Things', async () => {
     let rice;
 
     beforeEach(async () => {
-      [ soap ] = await Things.updateThing({ houseId: HOUSE, type: PANTRY, name: SOAP, value: 10 });
-      [ rice ] = await Things.updateThing({ houseId: HOUSE, type: PANTRY, name: RICE, value: 60 });
+      [ soap ] = await Things.updateThing({ houseId: HOUSE, type: PANTRY, name: SOAP, value: 10, metadata: { unit: '20 bars' } });
+      [ rice ] = await Things.updateThing({ houseId: HOUSE, type: PANTRY, name: RICE, value: 60, metadata: { unit: '25 lbs' } });
     });
 
     it('can buy a thing from the list', async () => {
@@ -247,6 +247,8 @@ describe('Things', async () => {
       let unfulfilledBuys;
       unfulfilledBuys = await Things.getUnfulfilledThingBuys(HOUSE, challengeEnd);
       expect(unfulfilledBuys.length).to.equal(1);
+      expect(unfulfilledBuys[0].thingMetadata.unit).to.equal('20 bars');
+      expect(unfulfilledBuys[0].metadata.quantity).to.equal(1);
 
       await Things.resolveThingBuy(buy.id, challengeEnd, numResidents);
 


### PR DESCRIPTION
Closes #71 

This PR adds a JSON `metadata` column to several datatypes, used to store non-query-related display data and metrics:

- [ ] Chore (markdown description)
- [x] ChoreValue (various stats)
- [x] ChoreBreak (destination)
- [x] Heart (type as `tinyint`, karma ranking)
- [x] HeartChallenge (circumstance)
- [x] Thing (quantity)
- [ ] Polls (Slack `messageId`)

JSON fields are a useful feature which adds a great deal of the flexibility associated with NoSQL databases without sacrificing the query performance associated with a more rigid SQL schema. Ultimately, fields which will be used as part of structured queries should be defined explicitly, while data which is only needed for display or analysis can be added to the json field.

Note: this PR is a continuation of https://github.com/zaratanDotWorld/mirror/commit/6ab3673782f7981a02a6ec2dd069e158e820f7df