### PR TITLE
Unify chore editing flow

### DIFF
--- a/migrations/20230828043719_ChoreProposal.js
+++ b/migrations/20230828043719_ChoreProposal.js
@@ -9,7 +9,7 @@ exports.up = function(knex) {
     t.string('houseId').references('House.slackId').notNull();
     t.string('proposedBy').references('Resident.slackId').notNull();
     t.integer('choreId').references('Chore.id');
-    t.string('name').notNull();
+    t.string('name');
     t.boolean('active').notNull().defaultTo(true);
     t.json('metadata').notNull().defaultTo({});
     t.integer('pollId').references('Poll.id').notNull();

--- a/src/bolt/chores.views.js
+++ b/src/bolt/chores.views.js
@@ -362,7 +362,8 @@ exports.choresProposeAddView = function () {
 
   return {
     type: 'modal',
-    callback_id: 'chores-propose-add-callback',
+    callback_id: 'chores-propose-callback',
+    private_metadata: JSON.stringify({ type: 'add' }),
     title: { type: 'plain_text', text: 'Chores', emoji: true },
     submit: { type: 'plain_text', text: 'Submit', emoji: true },
     close: { type: 'plain_text', text: 'Cancel', emoji: true },
@@ -404,7 +405,8 @@ exports.choresProposeDeleteView = function (chores) {
 
   return {
     type: 'modal',
-    callback_id: 'chores-propose-delete-callback',
+    callback_id: 'chores-propose-callback',
+    private_metadata: JSON.stringify({ type: 'delete' }),
     title: { type: 'plain_text', text: 'Chores', emoji: true },
     submit: { type: 'plain_text', text: 'Submit', emoji: true },
     close: { type: 'plain_text', text: 'Cancel', emoji: true },
@@ -462,8 +464,8 @@ exports.choresProposeEditView2 = function (chore) {
 
   return {
     type: 'modal',
-    callback_id: 'chores-propose-edit-callback',
-    private_metadata: `${chore.id}|${chore.name}`,
+    callback_id: 'chores-propose-callback',
+    private_metadata: JSON.stringify({ type: 'edit', chore }),
     title: { type: 'plain_text', text: 'Chores', emoji: true },
     submit: { type: 'plain_text', text: 'Submit', emoji: true },
     close: { type: 'plain_text', text: 'Cancel', emoji: true },

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -407,18 +407,6 @@ exports.createChoreProposal = async function (houseId, proposedBy, choreId, name
     .returning('*');
 };
 
-exports.createAddChoreProposal = async function (houseId, proposedBy, name, metadata, now) {
-  return exports.createChoreProposal(houseId, proposedBy, null, name, metadata, true, now);
-};
-
-exports.createDeleteChoreProposal = async function (houseId, proposedBy, choreId, name, now) {
-  return exports.createChoreProposal(houseId, proposedBy, choreId, name, {}, false, now);
-};
-
-exports.createEditChoreProposal = async function (houseId, proposedBy, choreId, name, metadata, now) {
-  return exports.createChoreProposal(houseId, proposedBy, choreId, name, metadata, true, now);
-};
-
 exports.getChoreProposal = async function (proposalId) {
   return db('ChoreProposal')
     .select('*')

--- a/test/chores.test.js
+++ b/test/chores.test.js
@@ -144,7 +144,7 @@ describe('Chores', async () => {
       expect(preferences.length).to.equal(3);
 
       // Remove the last two preferences
-      await Chores.deleteChore(HOUSE, restock.name);
+      await Chores.editChore(restock.id, restock.name, {}, false);
 
       preferences = await Chores.getActiveChorePreferences(HOUSE);
       expect(preferences.length).to.equal(1);
@@ -1021,7 +1021,7 @@ describe('Chores', async () => {
       let chores = await Chores.getChores(HOUSE);
       expect(chores.length).to.equal(1);
 
-      const [ deleteProposal ] = await Chores.createDeleteChoreProposal(HOUSE, RESIDENT1, addProposal.choreId, addProposal.name, now);
+      const [ deleteProposal ] = await Chores.createDeleteChoreProposal(HOUSE, RESIDENT1, chores[0].id, chores[0].name, now);
 
       await Polls.submitVote(deleteProposal.pollId, RESIDENT1, now, YAY);
       await Polls.submitVote(deleteProposal.pollId, RESIDENT2, now, YAY);
@@ -1058,6 +1058,11 @@ describe('Chores', async () => {
       const laundry2 = chores.find(x => x.name === 'laundry2');
       expect(laundry2.id).to.equal(laundryId);
       expect(laundry2.metadata.description).to.equal(description);
+    });
+
+    it('cannot create a proposal without either a choreId or name', async () => {
+      await expect(Chores.createChoreProposal(HOUSE, RESIDENT1, undefined, undefined, {}, true, now))
+        .to.be.rejectedWith('Proposal must include either choreId or name!');
     });
 
     it('cannot resolve a proposal before the poll is closed', async () => {


### PR DESCRIPTION
Closes #84

- Use `switch` statements to route behavior in a single function
- Combine proposal functions into a single function
- Combine callbacks into a single function
- Combine callback views into a single function