### PR TITLE
Limit voting to housemates only

### DIFF
--- a/migrations/20200329100300_Poll.js
+++ b/migrations/20200329100300_Poll.js
@@ -2,6 +2,7 @@ exports.up = function(knex, Promise) {
     return knex.schema.createTable('Poll', function(t) {
         t.increments('id').unsigned().primary();
         t.timestamps(useTimestamps = true, defaultToNow = true, useCamelCase = true);
+        // t.string('houseId').references('House.slackId').notNull();
         t.timestamp('startTime').notNull();
         t.timestamp('endTime').notNull();
         t.integer('minVotes').notNull();

--- a/migrations/20231008135304_poll_houseid.js
+++ b/migrations/20231008135304_poll_houseid.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.alterTable('Poll', function(t) {
+    t.string('houseId').references('House.slackId');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.alterTable('Poll', function(t) {
+    t.dropColumn('houseId');
+  });
+};

--- a/src/core/chores.js
+++ b/src/core/chores.js
@@ -215,7 +215,7 @@ exports.claimChore = async function (houseId, choreId, claimedBy, claimedAt) {
 
   if (choreValue.sum === null) { throw new Error('Cannot claim a zero-value chore!'); }
 
-  const [ poll ] = await Polls.createPoll(claimedAt, choresPollLength, choresMinVotes);
+  const [ poll ] = await Polls.createPoll(houseId, claimedAt, choresPollLength, choresMinVotes);
 
   return db('ChoreClaim')
     .insert({ houseId, choreId, claimedBy, claimedAt, value: choreValue.sum, pollId: poll.id })
@@ -398,7 +398,7 @@ exports.createChoreProposal = async function (houseId, proposedBy, choreId, name
   if (!(choreId || name)) { throw new Error('Proposal must include either choreId or name!'); }
 
   const minVotes = await exports.getChoreProposalMinVotes(houseId);
-  const [ poll ] = await Polls.createPoll(now, choresProposalPollLength, minVotes);
+  const [ poll ] = await Polls.createPoll(houseId, now, choresProposalPollLength, minVotes);
 
   return db('ChoreProposal')
     .insert({ houseId, proposedBy, choreId, name, metadata, active, pollId: poll.id })

--- a/src/core/hearts.js
+++ b/src/core/hearts.js
@@ -87,7 +87,7 @@ exports.issueChallenge = async function (houseId, challengerId, challengeeId, va
   if (unresolvedChallenges.length) { throw new Error('Active challenge exists!'); }
 
   const minVotes = await exports.getChallengeMinVotes(houseId, challengeeId, value, challengedAt);
-  const [ poll ] = await Polls.createPoll(challengedAt, heartsPollLength, minVotes);
+  const [ poll ] = await Polls.createPoll(houseId, challengedAt, heartsPollLength, minVotes);
 
   return db('HeartChallenge')
     .insert({ houseId, challengerId, challengeeId, challengedAt, value, pollId: poll.id, metadata: { circumstance } })

--- a/src/core/things.js
+++ b/src/core/things.js
@@ -68,7 +68,7 @@ exports.buyThing = async function (houseId, thingId, boughtBy, boughtAt, price, 
   if (houseBalance.sum < totalCost) { throw new Error('Insufficient funds!'); }
 
   const minVotes = await exports.getThingBuyMinVotes(houseId, thingId, totalCost);
-  const [ poll ] = await Polls.createPoll(boughtAt, thingsPollLength, minVotes);
+  const [ poll ] = await Polls.createPoll(houseId, boughtAt, thingsPollLength, minVotes);
 
   return db('ThingBuy')
     .insert({
@@ -89,7 +89,7 @@ exports.buySpecialThing = async function (houseId, boughtBy, boughtAt, price, ti
   if (houseBalance.sum < price) { throw new Error('Insufficient funds!'); }
 
   const minVotes = await exports.getThingBuyMinVotes(houseId, null, price);
-  const [ poll ] = await Polls.createPoll(boughtAt, thingsSpecialPollLength, minVotes);
+  const [ poll ] = await Polls.createPoll(houseId, boughtAt, thingsSpecialPollLength, minVotes);
 
   return db('ThingBuy')
     .insert({
@@ -183,7 +183,7 @@ exports.createThingProposal = async function (houseId, proposedBy, thingId, type
   if (!(thingId || (type && name))) { throw new Error('Proposal must include either thingId or type and name!'); }
 
   const minVotes = await exports.getThingProposalMinVotes(houseId);
-  const [ poll ] = await Polls.createPoll(now, thingsProposalPollLength, minVotes);
+  const [ poll ] = await Polls.createPoll(houseId, now, thingsProposalPollLength, minVotes);
 
   return db('ThingProposal')
     .insert({ houseId, proposedBy, thingId, type, name, value, metadata, active, pollId: poll.id })


### PR DESCRIPTION
Currently, any user can vote on a poll (at the database level). While not something which can be done via an interface, it is a brittle design which could lead to unexpected bugs down the road. This PR makes this process more secure.