### PR TITLE
Assign bulk chore penalties

### DIFF
--- a/src/bolt/chores.app.js
+++ b/src/bolt/chores.app.js
@@ -95,11 +95,13 @@ app.event('app_home_opened', async ({ body, event }) => {
     // Resolve any proposals
     await Chores.resolveChoreProposals(houseId, now);
 
-    // Give monthly penalty if needed
-    const [ penaltyHeart ] = await Chores.addChorePenalty(houseId, residentId, now);
-    if (penaltyHeart !== undefined && penaltyHeart.value < 0) {
-      const text = `You missed too many chores last month, and lost *${penaltyHeart.value.toFixed(1)}* hearts...`;
-      await postEphemeral(houseId, residentId, text); // TODO: make public?
+    // Give monthly penalties, if any
+    const penaltyHearts = await Chores.addChorePenalties(houseId, now);
+    for (const penaltyHeart of penaltyHearts) {
+      if (penaltyHeart.value < 0) {
+        const text = `You missed too many chores last month, and lost *${penaltyHeart.value.toFixed(1)}* hearts...`;
+        await postEphemeral(houseId, penaltyHeart.residentId, text);
+      }
     }
   }
 });


### PR DESCRIPTION
Closes #121

- Simplifies the database by writing all penalties as a contiguous set of entries
- Improves UX by ensuring that all updates are applied simultaneously