### PR TITLE
Migrate app configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "app:chores": "node src/bolt/chores.app.js",
     "app:things": "node src/bolt/things.app.js",
     "app:hearts": "node src/bolt/hearts.app.js",
-    "start:ngrok": "ngrok http --region=us --hostname=zaratan.ngrok.io 3000",
+    "ngrok": "ngrok http --region=us --hostname=zaratan.ngrok.io 3000",
     "prepare": "husky install",
     "pretest": "npx knex migrate:rollback --all --env test; npx knex migrate:latest --env test",
     "test": "NODE_ENV=test mocha --exit",

--- a/src/bolt/common.js
+++ b/src/bolt/common.js
@@ -232,15 +232,8 @@ exports.updateVoteResults = async function (app, oauth, pollId) {
   const { metadata } = await Polls.getPoll(pollId);
   const valid = await Polls.isPollValid(pollId);
 
-  // TODO: Remove this try/catch once all workspaces are upgraded
-  let message;
-  try {
-    const body = await exports.getMessage(app, oauth, metadata.channel, metadata.ts);
-    message = body.messages[0];
-  } catch (err) {
-    console.log(err);
-    return;
-  }
+  const body = await exports.getMessage(app, oauth, metadata.channel, metadata.ts);
+  const message = body.messages[0];
 
   // Parse current vote counts;
   const voteBlock = message.blocks.length - 1;

--- a/src/bolt/common.js
+++ b/src/bolt/common.js
@@ -115,7 +115,7 @@ exports.getMessage = async function (app, oauth, channelId, ts) {
 
 // Internal tools
 
-exports.setChannel = async function (app, oauth, command, channelType) {
+exports.setChannel = async function (app, oauth, confName, command) {
   if (!(await exports.isAdmin(app, oauth, command))) {
     await exports.replyAdminOnly(app, oauth, command);
     return;
@@ -128,7 +128,8 @@ exports.setChannel = async function (app, oauth, command, channelType) {
     'The app will use this channel to post polls and share public activity.';
   } else {
     const [ houseId, channelId ] = [ command.team_id, command.channel_id ];
-    await Admin.updateHouse(houseId, { [channelType]: channelId });
+    await Admin.updateHouseConf(houseId, confName, { channel: channelId });
+
     await app.client.conversations.join({ token: oauth.bot.token, channel: channelId });
     text = `App events channel set to *<#${channelId}>* :fire:`;
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,3 +14,7 @@ exports.HEART_REGEN = 1;
 exports.HEART_CHALLENGE = 2;
 exports.HEART_KARMA = 3;
 exports.HEART_CHORE = 4;
+
+exports.CHORES_CONF = 'choresConf';
+exports.HEARTS_CONF = 'heartsConf';
+exports.THINGS_CONF = 'thingsConf';

--- a/src/core/admin.js
+++ b/src/core/admin.js
@@ -15,14 +15,14 @@ exports.getHouse = async function (slackId) {
     .first();
 };
 
-exports.updateHouse = async function (slackId, metadata) {
+exports.updateHouseConf = async function (slackId, confName, conf) {
   // NOTE: May be possible as a single operation using a jsonb datatype
   const house = await exports.getHouse(slackId);
-  metadata = { ...house.metadata, ...metadata };
+  conf = { ...house[confName], ...conf };
 
   return db('House')
     .where({ slackId })
-    .update({ metadata })
+    .update(confName, conf)
     .returning('*');
 };
 

--- a/test/admin.test.js
+++ b/test/admin.test.js
@@ -5,7 +5,7 @@ const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
 const { Admin } = require('../src/core/index');
-const { HOUR, DAY } = require('../src/constants');
+const { HOUR, DAY, CHORES_CONF, THINGS_CONF } = require('../src/constants');
 const { getMonthStart, getMonthEnd, getNextMonthStart, getPrevMonthEnd, getDateStart } = require('../src/utils');
 const testHelpers = require('./helpers');
 const { db } = require('../src/core/db');
@@ -67,24 +67,30 @@ describe('Admin', async () => {
     it('can update house info', async () => {
       await Admin.addHouse(HOUSE1, 'h1');
 
+      const choresOauth = 'choresOauth';
+      const thingsOauth = 'thingsOauth';
       const choresChannel = 'choresChannel';
       const thingsChannel = 'thingsChannel';
 
-      await Admin.updateHouse(HOUSE1, { choresChannel });
-      await Admin.updateHouse(HOUSE1, { thingsChannel });
+      await Admin.updateHouseConf(HOUSE1, CHORES_CONF, { channel: choresChannel, oauth: choresOauth });
+      await Admin.updateHouseConf(HOUSE1, THINGS_CONF, { channel: thingsChannel, oauth: thingsOauth });
 
       let house;
 
       house = await Admin.getHouse(HOUSE1);
       expect(house.name).to.equal('h1');
-      expect(house.metadata.choresChannel).to.equal(choresChannel);
-      expect(house.metadata.thingsChannel).to.equal(thingsChannel);
+      expect(house.choresConf.channel).to.equal(choresChannel);
+      expect(house.choresConf.oauth).to.equal(choresOauth);
+      expect(house.thingsConf.channel).to.equal(thingsChannel);
+      expect(house.thingsConf.oauth).to.equal(thingsOauth);
 
-      await Admin.updateHouse(HOUSE1, { thingsChannel: null });
+      await Admin.updateHouseConf(HOUSE1, THINGS_CONF, { channel: null });
 
       house = await Admin.getHouse(HOUSE1);
-      expect(house.metadata.choresChannel).to.equal(choresChannel);
-      expect(house.metadata.thingsChannel).to.be.null;
+      expect(house.choresConf.channel).to.equal(choresChannel);
+      expect(house.choresConf.oauth).to.equal(choresOauth);
+      expect(house.thingsConf.channel).to.be.null;
+      expect(house.thingsConf.oauth).to.equal(thingsOauth);
     });
   });
 


### PR DESCRIPTION
Previously, all app configuration was stored in a single `metadata` blob. This is likely to be error-prone as more apps are added in the future. Migrating to a per-app configuration blob should keep things scalable in the longer term.